### PR TITLE
Combined dependencies PR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "autocfg"


### PR DESCRIPTION
Combining multiple dependencies PRs into one.

<details>
<summary>Instructions for merging</summary>

* **Use a merge commit**, so that GitHub will mark all original PRs as merged.
* If your repository does not have merge commits enabled, please temporarily enable them in settings. Tick `Allow merge commits` in the repository settings.
* When ready, merge this PR using `Create a merge commit`.

</details>

## Combined PRs

* Bump anyhow from 1.0.58 to 1.0.62 (#20) @dependabot
* Bump chrono from 0.4.19 to 0.4.22 (#18) @dependabot
* Bump futures from 0.3.21 to 0.3.23 (#17) @dependabot
* Bump thiserror from 1.0.31 to 1.0.32 (#16) @dependabot
* Bump tokio from 1.20.0 to 1.20.1 (#12) @dependabot
